### PR TITLE
Timeline: Discard entries for a partial week

### DIFF
--- a/Happiness/HappinessService.swift
+++ b/Happiness/HappinessService.swift
@@ -19,7 +19,16 @@ class HappinessService: NSObject {
     let googleMapsBaseURL = "https://maps.googleapis.com/maps/api/geocode/json?"
     let googleMapsAPIKey = "AIzaSyC0SxpBokzPt8_s-Jf6q1yzzt7WPibKHZc"
     
-    let getEntriesQueryLimit = 100
+    // For scrolling to work correctly, getEntriesQueryLimit must be greater
+    // than maxEntriesPerWeek. If we enforce a limit of maxEntriesPerWeek in
+    // the UI, a situation can still occur where multiple users create entries
+    // at the same time, thus exceeding maxEntriesPerWeek. To account for this,
+    // we set getEntriesQueryLimit to maxEntriesPerWeek plus a padding value of
+    // maxEntriesPerWeekPadding.
+    static let maxEntriesPerWeek = 100
+    static let maxEntriesPerWeekPadding = 20
+    let getEntriesQueryLimit = maxEntriesPerWeek + maxEntriesPerWeekPadding
+    
     let getNestUsersQueryLimit = 20
     
     var loginSuccess:((User) -> ())?

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following **required** functionality is completed:
    - [x] Use getEntries() to retrieve nest entries from service
    - [x] Use getEntries() beforeCreatedDate for infinite scroll
    - [x] Divide entries into sections by week
-   - [ ] Discard entries for a partial week
+   - [X] Discard entries for a partial week
    - [x] Add section header for current milestone even if it has no entries
    - [x] Only display entries for milestone if user created entry for that milestone
    - [x] Only allow swipe to delete for current user's entries


### PR DESCRIPTION
This code makes the assumption that there is always less than
getEntriesQueryLimit entries in a section. This is enforced using
maxEntriesPerWeek, which is less than getEntriesQueryLimit.